### PR TITLE
🧹 [Code Health] Rimuovi assegnazione let v4 commentata in LicensePlateReader.swift

### DIFF
--- a/TyreVibes/Core/Helper/LicensePlateReader.swift
+++ b/TyreVibes/Core/Helper/LicensePlateReader.swift
@@ -1865,18 +1865,6 @@ private static func preprocessCaptchaVariants(from cgImage: CGImage) -> [CGImage
         kCIInputEVKey: 0.6
     ])
 
-    // Variante 4: morfologia (erode + dilate) per ispessire/assottigliare
-   // let v4 = v1
-   //     .applyingFilter("CIMorphologyMinimum", parameters: [
-   //         kCIInputRadiusKey: 0.9
-   //     ])
-   //     .applyingFilter("CIMorphologyMaximum", parameters: [
-   //         kCIInputRadiusKey: 1.0
-   //     ])
-    
-   
-
-
     // Converte CIImage -> CGImage
     var out: [CGImage] = []
     for ci in [v1, v2, v3, vLens,


### PR DESCRIPTION
🎯 **Cosa:**
È stato rimosso un blocco di codice commentato (`// let v4 = v1.applyingFilter...`) all'interno di `TyreVibes/Core/Helper/LicensePlateReader.swift` che rappresentava codice morto (dead code).

💡 **Perché:**
Il codice commentato non veniva più utilizzato e occupava solo spazio nel file, peggiorando la leggibilità e la pulizia del sorgente. Rimuoverlo migliora la manutenibilità, riducendo le distrazioni per i futuri sviluppatori e mantenendo solo il codice in esecuzione.

✅ **Verifica:**
La rimozione riguarda esclusivamente codice già inattivo (commentato), pertanto non ha alcun impatto sulla logica dell'applicazione o sul comportamento a runtime. Non sono state introdotte regressioni funzionali.

✨ **Risultato:**
Il file `LicensePlateReader.swift` risulta ora più snello, pulito e facile da scorrere, senza vecchi blocchi di codice inutilizzati.

---
*PR created automatically by Jules for task [8448912055868832306](https://jules.google.com/task/8448912055868832306) started by @tenday*