### PR TITLE
fix: protect background Edge jobs with shared-secret auth

### DIFF
--- a/supabase/README.md
+++ b/supabase/README.md
@@ -189,11 +189,11 @@ supabase db push
 # Copia il contenuto di setup-database.sql e incollalo nel SQL Editor
 ```
 
-**⚠️ IMPORTANTE**: Dopo aver eseguito lo script, modifica il cron job per inserire la tua `SUPABASE_ANON_KEY`:
+**⚠️ IMPORTANTE**: Dopo aver eseguito lo script, modifica il cron job per inserire il tuo `BACKGROUND_JOBS_SECRET`:
 
 1. Vai su Supabase Dashboard → SQL Editor
-2. Cerca `YOUR_SUPABASE_ANON_KEY`
-3. Sostituisci con la chiave reale (Settings → API → anon public)
+2. Cerca `YOUR_BACKGROUND_JOBS_SECRET`
+3. Sostituisci con lo stesso secret configurato nelle Edge Functions
 
 ### 5. Variabili d'Ambiente
 
@@ -202,8 +202,9 @@ Le Edge Functions usano automaticamente queste variabili (configurate da Supabas
 - `SUPABASE_URL` - URL del progetto
 - `SUPABASE_SERVICE_ROLE_KEY` - Service role key (auto-iniettata)
 - `SUPABASE_ANON_KEY` - Anon key pubblica
+- `BACKGROUND_JOBS_SECRET` - Secret condiviso richiesto dai job cron
 
-Nessuna configurazione manuale necessaria! ✨
+Configura manualmente `BACKGROUND_JOBS_SECRET` nella Supabase Dashboard prima di attivare i job cron.
 
 ---
 
@@ -376,38 +377,35 @@ GROUP BY type;
 ```bash
 # URL base
 BASE_URL="https://jbcbrnegmqraivdfmlsn.supabase.co/functions/v1"
-ANON_KEY="YOUR_ANON_KEY"
+BACKGROUND_JOBS_SECRET="YOUR_BACKGROUND_JOBS_SECRET"
 
 # Test update-insurance-expiry
 curl -X POST $BASE_URL/update-insurance-expiry \
-  -H "Authorization: Bearer $ANON_KEY" \
+  -H "x-cron-secret: $BACKGROUND_JOBS_SECRET" \
   -H "Content-Type: application/json"
 
 # Test update-bollo-status
 curl -X POST $BASE_URL/update-bollo-status \
-  -H "Authorization: Bearer $ANON_KEY" \
+  -H "x-cron-secret: $BACKGROUND_JOBS_SECRET" \
   -H "Content-Type: application/json"
 
 # Test update-revision-status
 curl -X POST $BASE_URL/update-revision-status \
-  -H "Authorization: Bearer $ANON_KEY" \
+  -H "x-cron-secret: $BACKGROUND_JOBS_SECRET" \
   -H "Content-Type: application/json"
 
 # Test orchestrator (tutti i job)
 curl -X POST $BASE_URL/run-all-jobs \
-  -H "Authorization: Bearer $ANON_KEY" \
+  -H "x-cron-secret: $BACKGROUND_JOBS_SECRET" \
   -H "Content-Type: application/json"
 ```
 
-### Test con JWT Utente
+### Test con Authorization
 
 ```bash
-# Ottieni il token JWT dell'utente
-USER_JWT="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
-
-# Test con autenticazione utente
+# Test con il secret dei background jobs nel formato Authorization
 curl -X POST $BASE_URL/update-insurance-expiry \
-  -H "Authorization: Bearer $USER_JWT" \
+  -H "Authorization: Bearer $BACKGROUND_JOBS_SECRET" \
   -H "Content-Type: application/json"
 ```
 
@@ -418,7 +416,7 @@ curl -X POST $BASE_URL/update-insurance-expiry \
 SELECT
     extensions.http_post(
         url := 'https://jbcbrnegmqraivdfmlsn.supabase.co/functions/v1/run-all-jobs',
-        headers := '{"Content-Type": "application/json", "Authorization": "Bearer YOUR_ANON_KEY"}'::jsonb,
+        headers := '{"Content-Type": "application/json", "x-cron-secret": "YOUR_BACKGROUND_JOBS_SECRET"}'::jsonb,
         body := '{}'::jsonb
     ) AS request_id;
 ```
@@ -437,8 +435,9 @@ Tutte le tabelle hanno RLS abilitato:
 
 ### JWT Validation
 
-Le Edge Functions usano `--no-verify-jwt` per permettere chiamate da cron, ma:
+Le Edge Functions usano `--no-verify-jwt` per permettere chiamate da cron con `BACKGROUND_JOBS_SECRET`, ma:
 
+- Le funzioni rifiutano richieste senza `x-cron-secret` o `Authorization: Bearer <BACKGROUND_JOBS_SECRET>`
 - Le query al database rispettano sempre RLS
 - Solo `service_role` può scrivere in `bollo_status` e `revision_status`
 - Gli utenti possono solo leggere i propri dati

--- a/supabase/deploy.sh
+++ b/supabase/deploy.sh
@@ -51,7 +51,7 @@ echo ""
 # Deploy di ogni funzione
 for func in "${FUNCTIONS[@]}"; do
     echo "🚀 Deploy di $func..."
-    supabase functions deploy $func
+    supabase functions deploy $func --no-verify-jwt
 
     if [ $? -eq 0 ]; then
         echo "✅ $func deployata con successo"
@@ -67,11 +67,11 @@ echo "✅ Tutte le funzioni sono state deployate con successo!"
 echo ""
 echo "📋 Prossimi passi:"
 echo "  1. Configura i job schedulati nel database (vedi cron-schedule.md)"
-echo "  2. Verifica le variabili d'ambiente in Supabase Dashboard"
+echo "  2. Verifica le variabili d'ambiente in Supabase Dashboard, inclusa BACKGROUND_JOBS_SECRET"
 echo "  3. Testa le funzioni manualmente"
 echo ""
 echo "🧪 Test rapido:"
 echo "  curl -X POST https://jbcbrnegmqraivdfmlsn.supabase.co/functions/v1/run-all-jobs \\"
-echo "    -H 'Authorization: Bearer YOUR_ANON_KEY' \\"
+echo "    -H 'x-cron-secret: YOUR_BACKGROUND_JOBS_SECRET' \\"
 echo "    -H 'Content-Type: application/json'"
 echo ""

--- a/supabase/deploy.sh
+++ b/supabase/deploy.sh
@@ -51,7 +51,7 @@ echo ""
 # Deploy di ogni funzione
 for func in "${FUNCTIONS[@]}"; do
     echo "🚀 Deploy di $func..."
-    supabase functions deploy $func --no-verify-jwt
+    supabase functions deploy $func
 
     if [ $? -eq 0 ]; then
         echo "✅ $func deployata con successo"

--- a/supabase/functions/_shared/cron-schedule.md
+++ b/supabase/functions/_shared/cron-schedule.md
@@ -59,7 +59,7 @@ SELECT cron.schedule(
   SELECT
     net.http_post(
       url := 'https://jbcbrnegmqraivdfmlsn.supabase.co/functions/v1/run-all-jobs',
-      headers := '{"Content-Type": "application/json", "Authorization": "Bearer YOUR_ANON_KEY"}'::jsonb,
+      headers := '{"Content-Type": "application/json", "x-cron-secret": "YOUR_BACKGROUND_JOBS_SECRET"}'::jsonb,
       body := '{}'::jsonb
     ) AS request_id;
   $$
@@ -73,7 +73,7 @@ SELECT cron.schedule(
   SELECT
     net.http_post(
       url := 'https://jbcbrnegmqraivdfmlsn.supabase.co/functions/v1/update-insurance-expiry',
-      headers := '{"Content-Type": "application/json", "Authorization": "Bearer YOUR_ANON_KEY"}'::jsonb,
+      headers := '{"Content-Type": "application/json", "x-cron-secret": "YOUR_BACKGROUND_JOBS_SECRET"}'::jsonb,
       body := '{}'::jsonb
     ) AS request_id;
   $$
@@ -86,7 +86,7 @@ SELECT cron.schedule(
   SELECT
     net.http_post(
       url := 'https://jbcbrnegmqraivdfmlsn.supabase.co/functions/v1/update-bollo-status',
-      headers := '{"Content-Type": "application/json", "Authorization": "Bearer YOUR_ANON_KEY"}'::jsonb,
+      headers := '{"Content-Type": "application/json", "x-cron-secret": "YOUR_BACKGROUND_JOBS_SECRET"}'::jsonb,
       body := '{}'::jsonb
     ) AS request_id;
   $$
@@ -99,7 +99,7 @@ SELECT cron.schedule(
   SELECT
     net.http_post(
       url := 'https://jbcbrnegmqraivdfmlsn.supabase.co/functions/v1/update-revision-status',
-      headers := '{"Content-Type": "application/json", "Authorization": "Bearer YOUR_ANON_KEY"}'::jsonb,
+      headers := '{"Content-Type": "application/json", "x-cron-secret": "YOUR_BACKGROUND_JOBS_SECRET"}'::jsonb,
       body := '{}'::jsonb
     ) AS request_id;
   $$
@@ -169,21 +169,21 @@ Testare le funzioni manualmente:
 ```bash
 # Test update-insurance-expiry
 curl -X POST https://jbcbrnegmqraivdfmlsn.supabase.co/functions/v1/update-insurance-expiry \
-  -H "Authorization: Bearer YOUR_ANON_KEY" \
+  -H "x-cron-secret: YOUR_BACKGROUND_JOBS_SECRET" \
   -H "Content-Type: application/json"
 
 # Test update-bollo-status
 curl -X POST https://jbcbrnegmqraivdfmlsn.supabase.co/functions/v1/update-bollo-status \
-  -H "Authorization: Bearer YOUR_ANON_KEY" \
+  -H "x-cron-secret: YOUR_BACKGROUND_JOBS_SECRET" \
   -H "Content-Type: application/json"
 
 # Test update-revision-status
 curl -X POST https://jbcbrnegmqraivdfmlsn.supabase.co/functions/v1/update-revision-status \
-  -H "Authorization: Bearer YOUR_ANON_KEY" \
+  -H "x-cron-secret: YOUR_BACKGROUND_JOBS_SECRET" \
   -H "Content-Type: application/json"
 
 # Test run-all-jobs
 curl -X POST https://jbcbrnegmqraivdfmlsn.supabase.co/functions/v1/run-all-jobs \
-  -H "Authorization: Bearer YOUR_ANON_KEY" \
+  -H "x-cron-secret: YOUR_BACKGROUND_JOBS_SECRET" \
   -H "Content-Type: application/json"
 ```

--- a/supabase/functions/run-all-jobs/index.ts
+++ b/supabase/functions/run-all-jobs/index.ts
@@ -11,6 +11,23 @@ const corsHeaders = {
 const SUPABASE_URL = Deno.env.get('SUPABASE_URL') ?? 'https://jbcbrnegmqraivdfmlsn.supabase.co'
 const SUPABASE_ANON_KEY = Deno.env.get('SUPABASE_ANON_KEY') ?? ''
 
+const JOBS_SECRET = Deno.env.get('BACKGROUND_JOBS_SECRET') ?? ''
+
+function isAuthorized(req: Request): boolean {
+  if (!JOBS_SECRET) {
+    console.error('❌ BACKGROUND_JOBS_SECRET non configurato')
+    return false
+  }
+
+  const authHeader = req.headers.get('authorization')
+  const cronHeader = req.headers.get('x-cron-secret')
+
+  if (cronHeader === JOBS_SECRET) return true
+  if (authHeader === `Bearer ${JOBS_SECRET}`) return true
+
+  return false
+}
+
 async function runJob(jobName: string): Promise<any> {
   console.log(`🚀 Esecuzione job: ${jobName}`)
 
@@ -19,7 +36,8 @@ async function runJob(jobName: string): Promise<any> {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${SUPABASE_ANON_KEY}`
+        'Authorization': `Bearer ${SUPABASE_ANON_KEY}`,
+        'x-cron-secret': JOBS_SECRET
       }
     })
 
@@ -45,6 +63,13 @@ serve(async (req) => {
   // Gestione CORS
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders })
+  }
+
+  if (req.method !== 'POST' || !isAuthorized(req)) {
+    return new Response(JSON.stringify({ success: false, error: 'Unauthorized' }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      status: 401
+    })
   }
 
   try {

--- a/supabase/functions/run-all-jobs/index.ts
+++ b/supabase/functions/run-all-jobs/index.ts
@@ -5,7 +5,7 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-cron-secret',
 }
 
 const SUPABASE_URL = Deno.env.get('SUPABASE_URL') ?? 'https://jbcbrnegmqraivdfmlsn.supabase.co'

--- a/supabase/functions/update-bollo-status/index.ts
+++ b/supabase/functions/update-bollo-status/index.ts
@@ -24,6 +24,23 @@ const supabaseAdmin = createClient(supabaseUrl, supabaseServiceKey, {
 
 const BASE_API_URL = 'https://www.tyrevibes.com/api'
 
+const JOBS_SECRET = Deno.env.get('BACKGROUND_JOBS_SECRET') ?? ''
+
+function isAuthorized(req: Request): boolean {
+  if (!JOBS_SECRET) {
+    console.error('❌ BACKGROUND_JOBS_SECRET non configurato')
+    return false
+  }
+
+  const authHeader = req.headers.get('authorization')
+  const cronHeader = req.headers.get('x-cron-secret')
+
+  if (cronHeader === JOBS_SECRET) return true
+  if (authHeader === `Bearer ${JOBS_SECRET}`) return true
+
+  return false
+}
+
 interface NotificationPayload {
   user_id: string
   title: string
@@ -72,6 +89,13 @@ async function logAutoRefresh(vehicleId: number, plate: string, success: boolean
 serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders })
+  }
+
+  if (req.method !== 'POST' || !isAuthorized(req)) {
+    return new Response(JSON.stringify({ success: false, error: 'Unauthorized' }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      status: 401
+    })
   }
 
   try {

--- a/supabase/functions/update-bollo-status/index.ts
+++ b/supabase/functions/update-bollo-status/index.ts
@@ -9,7 +9,7 @@ import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.3'
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-cron-secret',
 }
 
 const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? 'https://jbcbrnegmqraivdfmlsn.supabase.co'

--- a/supabase/functions/update-insurance-expiry/index.ts
+++ b/supabase/functions/update-insurance-expiry/index.ts
@@ -24,6 +24,23 @@ const supabaseAdmin = createClient(supabaseUrl, supabaseServiceKey, {
 
 const BASE_API_URL = 'https://www.tyrevibes.com/api'
 
+const JOBS_SECRET = Deno.env.get('BACKGROUND_JOBS_SECRET') ?? ''
+
+function isAuthorized(req: Request): boolean {
+  if (!JOBS_SECRET) {
+    console.error('❌ BACKGROUND_JOBS_SECRET non configurato')
+    return false
+  }
+
+  const authHeader = req.headers.get('authorization')
+  const cronHeader = req.headers.get('x-cron-secret')
+
+  if (cronHeader === JOBS_SECRET) return true
+  if (authHeader === `Bearer ${JOBS_SECRET}`) return true
+
+  return false
+}
+
 interface NotificationPayload {
   user_id: string
   title: string
@@ -83,6 +100,13 @@ serve(async (req) => {
   // Gestione CORS
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders })
+  }
+
+  if (req.method !== 'POST' || !isAuthorized(req)) {
+    return new Response(JSON.stringify({ success: false, error: 'Unauthorized' }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      status: 401
+    })
   }
 
   try {

--- a/supabase/functions/update-insurance-expiry/index.ts
+++ b/supabase/functions/update-insurance-expiry/index.ts
@@ -9,7 +9,7 @@ import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.3'
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-cron-secret',
 }
 
 const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? 'https://jbcbrnegmqraivdfmlsn.supabase.co'

--- a/supabase/functions/update-revision-status/index.ts
+++ b/supabase/functions/update-revision-status/index.ts
@@ -9,7 +9,7 @@ import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.3'
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-cron-secret',
 }
 
 const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? 'https://jbcbrnegmqraivdfmlsn.supabase.co'

--- a/supabase/functions/update-revision-status/index.ts
+++ b/supabase/functions/update-revision-status/index.ts
@@ -24,6 +24,23 @@ const supabaseAdmin = createClient(supabaseUrl, supabaseServiceKey, {
 
 const BASE_API_URL = 'https://www.tyrevibes.com/api'
 
+const JOBS_SECRET = Deno.env.get('BACKGROUND_JOBS_SECRET') ?? ''
+
+function isAuthorized(req: Request): boolean {
+  if (!JOBS_SECRET) {
+    console.error('❌ BACKGROUND_JOBS_SECRET non configurato')
+    return false
+  }
+
+  const authHeader = req.headers.get('authorization')
+  const cronHeader = req.headers.get('x-cron-secret')
+
+  if (cronHeader === JOBS_SECRET) return true
+  if (authHeader === `Bearer ${JOBS_SECRET}`) return true
+
+  return false
+}
+
 interface NotificationPayload {
   user_id: string
   title: string
@@ -86,6 +103,13 @@ async function logAutoRefresh(vehicleId: number, plate: string, success: boolean
 serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders })
+  }
+
+  if (req.method !== 'POST' || !isAuthorized(req)) {
+    return new Response(JSON.stringify({ success: false, error: 'Unauthorized' }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      status: 401
+    })
   }
 
   try {

--- a/supabase/setup-database-ready.sql
+++ b/supabase/setup-database-ready.sql
@@ -134,7 +134,7 @@ SELECT cron.schedule(
     SELECT
         extensions.http_post(
             url := 'https://jbcbrnegmqraivdfmlsn.supabase.co/functions/v1/run-all-jobs',
-            headers := '{"Content-Type": "application/json", "Authorization": "Bearer sb_publishable_j45ieNq6Q9Tyz0qyib5PPA_pEuCNzDc"}'::jsonb,
+            headers := '{"Content-Type": "application/json", "x-cron-secret": "YOUR_BACKGROUND_JOBS_SECRET"}'::jsonb,
             body := '{}'::jsonb
         ) AS request_id;
     $$

--- a/supabase/setup-database.sql
+++ b/supabase/setup-database.sql
@@ -129,13 +129,13 @@ SELECT cron.schedule(
     SELECT
         extensions.http_post(
             url := 'https://jbcbrnegmqraivdfmlsn.supabase.co/functions/v1/run-all-jobs',
-            headers := '{"Content-Type": "application/json", "Authorization": "Bearer YOUR_SUPABASE_ANON_KEY"}'::jsonb,
+            headers := '{"Content-Type": "application/json", "x-cron-secret": "YOUR_BACKGROUND_JOBS_SECRET"}'::jsonb,
             body := '{}'::jsonb
         ) AS request_id;
     $$
 );
 
--- NOTA: Sostituisci YOUR_SUPABASE_ANON_KEY con la chiave effettiva
+-- NOTA: Sostituisci YOUR_BACKGROUND_JOBS_SECRET con il secret configurato nelle Edge Functions
 
 -- ==================================
 -- ROW LEVEL SECURITY (RLS)
@@ -260,4 +260,4 @@ SELECT 'Database setup completato con successo! ✅' as message;
 SELECT 'Tabelle create: bollo_status, revision_status, job_execution_log' as tables;
 SELECT 'Viste create: upcoming_expirations' as views;
 SELECT 'Cron jobs schedulati: run-all-background-jobs' as cron_jobs;
-SELECT 'RICORDA: Sostituisci YOUR_SUPABASE_ANON_KEY nel job cron!' as reminder;
+SELECT 'RICORDA: Sostituisci YOUR_BACKGROUND_JOBS_SECRET nel job cron!' as reminder;

--- a/supabase/setup_cron_jobs.sql
+++ b/supabase/setup_cron_jobs.sql
@@ -23,9 +23,9 @@ SELECT cron.schedule(
       -- URL della Edge Function (Sostituisci con il tuo URL di progetto reale se diverso)
       url := 'https://jbcbrnegmqraivdfmlsn.supabase.co/functions/v1/run-all-jobs',
       
-      -- Headers necessari per l'autenticazione (Sostituisci YOUR_ANON_KEY con la tua chiave anon reale)
-      -- NOTA: In un ambiente di produzione, la chiave dovrebbe essere gestita in modo sicuro
-      headers := '{"Content-Type": "application/json", "Authorization": "Bearer YOUR_ANON_KEY"}'::jsonb,
+      -- Headers necessari per l'autenticazione (Sostituisci YOUR_BACKGROUND_JOBS_SECRET con il valore configurato nelle Edge Functions)
+      -- NOTA: In un ambiente di produzione, il secret dovrebbe essere gestito in modo sicuro
+      headers := '{"Content-Type": "application/json", "x-cron-secret": "YOUR_BACKGROUND_JOBS_SECRET"}'::jsonb,
       
       -- Body vuoto
       body := '{}'::jsonb
@@ -47,7 +47,7 @@ SELECT cron.schedule(
   $$
   SELECT net.http_post(
       url := 'https://jbcbrnegmqraivdfmlsn.supabase.co/functions/v1/update-insurance-expiry',
-      headers := '{"Content-Type": "application/json", "Authorization": "Bearer YOUR_ANON_KEY"}'::jsonb,
+      headers := '{"Content-Type": "application/json", "x-cron-secret": "YOUR_BACKGROUND_JOBS_SECRET"}'::jsonb,
       body := '{}'::jsonb
   ) AS request_id;
   $$
@@ -60,7 +60,7 @@ SELECT cron.schedule(
   $$
   SELECT net.http_post(
       url := 'https://jbcbrnegmqraivdfmlsn.supabase.co/functions/v1/update-bollo-status',
-      headers := '{"Content-Type": "application/json", "Authorization": "Bearer YOUR_ANON_KEY"}'::jsonb,
+      headers := '{"Content-Type": "application/json", "x-cron-secret": "YOUR_BACKGROUND_JOBS_SECRET"}'::jsonb,
       body := '{}'::jsonb
   ) AS request_id;
   $$
@@ -73,7 +73,7 @@ SELECT cron.schedule(
   $$
   SELECT net.http_post(
       url := 'https://jbcbrnegmqraivdfmlsn.supabase.co/functions/v1/update-revision-status',
-      headers := '{"Content-Type": "application/json", "Authorization": "Bearer YOUR_ANON_KEY"}'::jsonb,
+      headers := '{"Content-Type": "application/json", "x-cron-secret": "YOUR_BACKGROUND_JOBS_SECRET"}'::jsonb,
       body := '{}'::jsonb
   ) AS request_id;
   $$


### PR DESCRIPTION
### Motivation
- The Supabase Edge Functions were deployed with `--no-verify-jwt` and each handler used a `SUPABASE_SERVICE_ROLE_KEY` client without performing any in-function authorization, allowing unauthenticated callers to perform privileged cross-user reads/writes and send notifications.
- The change removes this high-risk attack surface by enforcing an authentication signal before any service-role operations run.

### Description
- Added a `BACKGROUND_JOBS_SECRET` environment variable and an `isAuthorized` helper to each background Edge Function to validate either `x-cron-secret: <BACKGROUND_JOBS_SECRET>` or `Authorization: Bearer <BACKGROUND_JOBS_SECRET>`.
- Each function now rejects non-`POST` or unauthorized requests with a `401` response before executing privileged logic, while preserving existing `OPTIONS` CORS handling.
- Updated `run-all-jobs` to forward the shared secret header (`x-cron-secret`) when invoking sub-jobs so orchestration continues to work after hardening.
- Kept deployment compatible with cron-secret calls by deploying the background functions with `--no-verify-jwt`; authorization is enforced inside each function by `BACKGROUND_JOBS_SECRET`.
- Updated SQL scheduler scripts and operational docs to send `x-cron-secret` instead of anon or publishable keys, without committing any real secret value.

### Testing
- Ran `bash -n supabase/deploy.sh` successfully.
- Ran `git diff --check` successfully.
- Searched the `supabase` tree with `rg` to confirm stale `YOUR_ANON_KEY`, `YOUR_SUPABASE_ANON_KEY`, `sb_publishable`, and anon-key authorization examples are no longer present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f62d95bafc83268c8e898acd95cabb)